### PR TITLE
Change: node.ffmd statt nextnode.ffmd

### DIFF
--- a/ffmd.zone
+++ b/ffmd.zone
@@ -12,7 +12,7 @@ ns1.ffmdnic                         A       10.139.0.53
                                     AAAA    fda9:26e:5805::9
                                     AAAA    fda9:26e:5805::2
 ;
-nextnode                            A       10.139.0.1
+node                                A       10.139.0.1
                                     AAAA    fda9:026e:5805::1
 ;
 1.ntp                               AAAA    fda9:26e:5805::9


### PR DESCRIPTION
Could we use 'node.ffmd' instead of 'nextnode.ffmd'?

Think it's easier to remember, shorter & makes more sense to me. :D